### PR TITLE
Add dark mode that respects OS setting

### DIFF
--- a/static/main.css
+++ b/static/main.css
@@ -1,3 +1,20 @@
+/* light and dark mode */
+
+:root {
+  --color1: white;
+  --color2: black;
+  --color3: grey;
+  --filter: none;
+}
+
+@media (prefers-color-scheme: dark) {
+  :root {
+    --color1: black;
+    --color2: white;
+    --filter: invert(1);
+  }
+}
+
 /* general */
 
 body {
@@ -7,9 +24,40 @@ body {
   margin: auto;
   border: none;
   padding: 1rem;
+  background-color: var(--color1);
+  color: var(--color2);
+}
+
+/* logo */
+
+img {
+  filter: var(--filter);
+}
+
+/* links */
+
+a {
+  color: var(--color2);
 }
 
 /* link form */
+
+input {
+  font-family: inherit;
+  padding: 0.25rem 0.5rem;
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  outline: solid 1px var(--color2);
+  background-color: var(--color1);
+  color: var(--color2);
+  -webkit-appearance: none;
+}
+
+input:focus {
+  background-color: var(--color2);
+  color: var(--color1);
+}
 
 #form {
   display: grid;


### PR DESCRIPTION
This PR adds a dark mode to 29.FYI that respects the OS appearance setting. For example, if you have dark appearance turned on on iPhone, you'll get the dark mode version. This PR also makes slight changes to the now light mode appearance.

# Light mode

![29.FYI in light mode, white background, black text](https://user-images.githubusercontent.com/23199821/92107645-09bb1680-edde-11ea-9637-a94cff5fa6af.png)

# Dark mode

![29.FYI in light mode, black background, white text](https://user-images.githubusercontent.com/23199821/92107667-0fb0f780-edde-11ea-807b-94b2d9fe4eb9.png)